### PR TITLE
fix(build): replace zlib.net URL with GitHub

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -54,8 +54,8 @@ build_boringssl() {
 # Build zlib
 build_zlib() {
   if [[ ! -d "$ZLIB_SRC_DIR" ]]; then
-    curl -LO "https://zlib.net/fossils/zlib-$ZLIB_VERSION.tar.gz"
-    tar xf "zlib-$ZLIB_VERSION.tar.gz"
+    curl -LO "https://github.com/madler/zlib/archive/refs/tags/v$ZLIB_VERSION.tar.gz"
+    tar xf "v$ZLIB_VERSION.tar.gz"
   fi
   cd "$ZLIB_SRC_DIR"
   CHOST=$HOST CFLAGS="-fPIC" ./configure --prefix="$ZLIB_OUT_DIR"


### PR DESCRIPTION
The install.sh script failed when fetching zlib-1.3 because zlib.net/fossils returns an HTML 415 response instead of a tarball. This caused `tar` to abort with "not in gzip format".

Updated build_zlib() to download from the official GitHub releases (madler/zlib).